### PR TITLE
Extract parameters in properties

### DIFF
--- a/src/main/java/io/spring/stats/SampleApplication.java
+++ b/src/main/java/io/spring/stats/SampleApplication.java
@@ -3,9 +3,11 @@ package io.spring.stats;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
+@EnableConfigurationProperties(StatsProperties.class)
 public class SampleApplication {
 
 	public static void main(String[] args) {
@@ -14,26 +16,22 @@ public class SampleApplication {
 
 	@Bean
 	public ApplicationRunner statisticsRunner(MavenCentralStatistics mavenCentralStatistics,
-			ProjectCreationStatistics projectCreationStatistics) {
+			ProjectCreationStatistics projectCreationStatistics, StatsProperties statsProperties) {
 		return args -> {
-			// gav coordinates of the module to consider for Maven Central Stats
-			String groupId = "org.springframework.batch";
-			String artifactId = "spring-batch-core";
 
-			// dependency id of an entry on start.spring.io
-			// curl https://start.spring.io provides a table of available dependency ids.
-			String dependencyId = "batch";
-
-			int year = 2020;
-			System.out.printf("Maven Central statistics for '%s:%s':%n", groupId, artifactId);
+			System.out.printf("Maven Central statistics for '%s:%s':%n", statsProperties.getGroupId(),
+					statsProperties.getArtifactId());
 			for (int month = 1; month <= 12; month++) {
-				System.out.printf("%s-%02d - %s%n", year, month,
-						mavenCentralStatistics.getMonthlyDownloadCount(groupId, artifactId, year, month));
+				System.out.printf("%s-%02d - %s%n", statsProperties.getYear(), month,
+						mavenCentralStatistics.getMonthlyDownloadCount(statsProperties.getGroupId(),
+								statsProperties.getArtifactId(), statsProperties.getYear(), month));
 			}
-			System.out.printf("start.spring.io generation statistics for projects with entry '%s':%n", dependencyId);
+			System.out.printf("start.spring.io generation statistics for projects with entry '%s':%n",
+					statsProperties.getDependencyId());
 			for (int month = 1; month <= 12; month++) {
-				System.out.printf("%s-%02d - %s%n", year, month,
-						projectCreationStatistics.getMonthlyProjectCreationCount(dependencyId, year, month));
+				System.out.printf("%s-%02d - %s%n", statsProperties.getYear(), month,
+						projectCreationStatistics.getMonthlyProjectCreationCount(statsProperties.getDependencyId(),
+								statsProperties.getYear(), month));
 			}
 		};
 	}

--- a/src/main/java/io/spring/stats/StatsProperties.java
+++ b/src/main/java/io/spring/stats/StatsProperties.java
@@ -1,0 +1,51 @@
+package io.spring.stats;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Simon Baslé
+ */
+@ConfigurationProperties(prefix = "stats")
+public class StatsProperties {
+
+	private String groupId;
+
+	private String artifactId;
+
+	private String dependencyId;
+
+	private int year;
+
+	public String getGroupId() {
+		return groupId;
+	}
+
+	public void setGroupId(String groupId) {
+		this.groupId = groupId;
+	}
+
+	public String getArtifactId() {
+		return artifactId;
+	}
+
+	public void setArtifactId(String artifactId) {
+		this.artifactId = artifactId;
+	}
+
+	public String getDependencyId() {
+		return dependencyId;
+	}
+
+	public void setDependencyId(String dependencyId) {
+		this.dependencyId = dependencyId;
+	}
+
+	public int getYear() {
+		return year;
+	}
+
+	public void setYear(int year) {
+		this.year = year;
+	}
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,11 @@
 # spring.elasticsearch.rest.* properties must be configured to point to the backend
+spring.elasticsearch.rest.uris=BACKEND
+spring.elasticsearch.rest.username=USERNAME
+spring.elasticsearch.rest.password=PASSWORD
+#gav coordinates of the module to consider for Maven Central Stats
+stats.groupId=id.group
+stats.artifactId=artifact-id
+#dependency id of an entry on start.spring.io
+#curl https://start.spring.io provides a table of available dependency ids.
+stats.dependencyId=start-dependency
+stats.year=2020


### PR DESCRIPTION
This commit extracts the parameters to the job into properties,
documenting all properties in the example application.properties and
making it the single point of editing needed to run the job.